### PR TITLE
Edición de Expediente sin select2

### DIFF
--- a/hercules/blueprints/arc_documentos/templates/arc_documentos/edit.jinja2
+++ b/hercules/blueprints/arc_documentos/templates/arc_documentos/edit.jinja2
@@ -139,7 +139,7 @@
             $('#juzgado_id').select2({
                 // --- Carga de emails por Ajax --- //
                 ajax: {
-                    url: '/autoridades/juzgados_json',
+                    url: '/autoridades/select_json',
                     headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" },
                     dataType: 'json',
                     delay: 250,


### PR DESCRIPTION
Se reparó la nueva dirección que tenía la función select2 en el formulario de edición de Expediente