### PR TITLE
Mejora en bitácora de Arc_Remesas

### DIFF
--- a/hercules/blueprints/arc_remesas_documentos/views.py
+++ b/hercules/blueprints/arc_remesas_documentos/views.py
@@ -284,14 +284,6 @@ def archive(arc_remesa_documento_id):
                     accion="ARCHIVAR",
                 )
                 documento_bitacora.save()
-                # Añadir acción a la bitácora del sistema
-                bitacora = Bitacora(
-                    modulo=Modulo.query.filter_by(nombre=MODULO).first(),
-                    usuario=current_user,
-                    descripcion=safe_message(f"Documento {documento.id} Archivado."),
-                    url=url_for("arc_archivos.list_active"),
-                )
-                bitacora.save()
                 # Actualizamos el número de anomalías registradas en la remesa padre
                 remesa = ArcRemesa.query.get_or_404(remesa_documento.arc_remesa_id)
                 num_anomalias = (


### PR DESCRIPTION
Quité el registro que se hace en bitácora cada vez que se archiva un documento anexo de una remesa. Genera demasiados registros en el reporte envía a mi email.