### PR TITLE
corrección de posible bug

### DIFF
--- a/hercules/blueprints/arc_remesas/views.py
+++ b/hercules/blueprints/arc_remesas/views.py
@@ -520,7 +520,9 @@ def recover(remesa_id):
     documentos = ArcRemesaDocumento.query.filter_by(arc_remesa_id=remesa_id).all()
     for documento in documentos:
         documento_anexo = ArcRemesaDocumento.query.join(ArcRemesa).filter(ArcRemesaDocumento.arc_remesa_id != remesa_id)
-        documento_anexo = documento_anexo.filter(or_(ArcRemesa.estado != "CANCELADO", ArcRemesa.estado != "ARCHIVADO"))
+        documento_anexo = documento_anexo.filter(
+            or_(ArcRemesa.estado != "CANCELADO", ArcRemesa.estado != "ARCHIVADO", ArcRemesa.estado != "ARCHIVADO CON ANOMALIA")
+        )
         documento_anexo = (
             documento_anexo.filter(ArcRemesaDocumento.arc_documento_id == documento.arc_documento.id)
             .filter_by(estatus="A")


### PR DESCRIPTION
Me reportaron que no pueden recuperar una remesa cancelada. Que le aparece un mensaje que dice que está siendo utilizada por otra. Me fijé y fue enviada hace tiempo en otra remesa que se archivo con anomalías. Yo hago una búsqueda que revisa que no este siendo utilizado otras remesas el mismo expediente.
Añadí: Remesas Archivas con Anomalías en las condiciones de búsqueda de expedientes.